### PR TITLE
Remove feature components that activate features of dev-dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -989,9 +989,9 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "registry-conformance"
-version = "0.5.1"
+version = "0.5.2"
 source = "sparse+https://integer32llc.github.io/registry-conformance/"
-checksum = "e7832c5e5390f7d9546f65df6b36758bd755c82310c43255a741e8bd9524101c"
+checksum = "7bf0349976913b09e95602e5dcab7f99a6792c389404e972582a6bf387656b7a"
 dependencies = [
  "base64",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ lint_groups_priority = { level = "allow", priority = 1 } # Remove after 1.80. ht
 
 [workspace.dependencies]
 argh = { version = "0.1.12", default-features = false }
-registry-conformance = { version = "0.5.0", registry = "registry-conformance" }
+registry-conformance = { version = "0.5.2", registry = "registry-conformance" }
 snafu = { version = "0.8.2", default-features = false, features = ["rust_1_65", "std"] }
 tokio = { version = "1.37.0", default-features = false, features = ["macros", "process", "rt-multi-thread"] }
 


### PR DESCRIPTION
For example, syn has a feature `test` that activates the
`all-features` feature of the dev-dependency `syn-test-suite`:

```toml
[features]
test = ["syn-test-suite/all-features"]

[dev-dependencies.syn-test-suite]
version = "0"
```

We don't store the dev-dependencies in the index which causes Cargo to
complain when fetching `syn` because the feature refers to a
dependency that doesn't exist.