### PR TITLE
Accept multiple paths in add

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,7 @@ struct AddArgs {
     registry: Option<PathBuf>,
 
     #[argh(positional)]
-    path: PathBuf,
+    path: Vec<PathBuf>,
 }
 
 /// Remove a crate from the registry
@@ -329,7 +329,9 @@ enum DoInitializeError {
 fn do_add(global: &Global, add: AddArgs) -> Result<(), Error> {
     let r = discover_registry(add.registry)?;
 
-    r.add(global, &add.path)?;
+    for i in add.path {
+        r.add(global, i)?;
+    }
     r.maybe_generate_html()?;
 
     Ok(())


### PR DESCRIPTION
This helps being able to do something like:
```
margo add --registry ... ~/.cargo/registry/cache/index.crates.io-6f17d22bba15001f/*
```

The output is a little too verbose for me, but that can be changed later.